### PR TITLE
Added file levels feature

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -45,6 +45,22 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('mock_image')
                     ->defaultValue('%kernel.debug%')
                 ->end()
+                ->scalarNode('file_levels')
+                    ->defaultValue('2:8')
+                    ->validate()
+                        ->ifTrue(function ($v) {
+                            $n = explode(':', $v);
+                            foreach ($n as $i) {
+                                if ($i !== (string) (int) $i || $i < 1 || $i > 31) {
+                                    return true;
+                                }
+                            }
+
+                            return false;
+                        })
+                        ->thenInvalid('Correct form: xx or xx:xx or xx:xx:xx or...')
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/ImageManager.php
+++ b/src/ImageManager.php
@@ -49,6 +49,7 @@ class ImageManager
         'driver' => 'gd',
         'image_dir' => '',
         'mock_image' => false,
+        'file_levels' => '2:8',
     ];
 
     /**
@@ -132,11 +133,16 @@ class ImageManager
     {
         $name = $image->getHash();
 
+        $fileLevels = explode(':', $this->options['file_levels']);
+        $hashs = '';
+        foreach ($fileLevels as $level) {
+            $hashs .= '/'.substr($name, 0, $level);
+        }
+
         return [
-            'directory' => sprintf('%s/%s/%s',
+            'directory' => sprintf('%s%s',
                 $this->options['prefix'],
-                substr($name, 0, 2),
-                substr($name, 0, 8)
+                $hashs
             ),
             'name' => sprintf('%s_%s_%s.%s',
                 $name,

--- a/src/Routing/Loader/ImageLoader.php
+++ b/src/Routing/Loader/ImageLoader.php
@@ -31,6 +31,7 @@ class ImageLoader extends Loader
      */
     private $options = [
         'prefix' => '/assets/images',
+        'file_levels' => '2:8',
     ];
 
     /**
@@ -55,18 +56,27 @@ class ImageLoader extends Loader
         $routes = new RouteCollection();
 
         // prepare a new route
-        $path = rtrim($this->options['prefix'], '/').'/{hash2}/{hash8}/{hash}_{size}_{aspect}.{type}';
+        $fileLevels = explode(':', $this->options['file_levels']);
+        $hashs = '';
+        foreach ($fileLevels as $key => $level) {
+            $hashs .= '/{hash'.$key.'}';
+        }
+
+        $path = rtrim($this->options['prefix'], '/').$hashs.'/{hash}_{size}_{aspect}.{type}';
         $defaults = [
             '_controller' => 'ingalabs_image.image_controller:showAction',
         ];
         $requirements = [
-            'hash2' => '[a-zA-Z0-9]{2}',
-            'hash8' => '[a-zA-Z0-9]{8}',
             'hash' => '[a-zA-Z0-9]{32}',
             'size' => '[a-zA-Z0-9]+',
             'aspect' => '[a-zA-Z0-9]+',
             'type' => '[a-zA-Z0-9]+',
         ];
+
+        foreach ($fileLevels as $key => $level) {
+            $requirements['hash'.$key] = '[a-zA-Z0-9]{'.$level.'}';
+        }
+
         $route = new Route($path, $defaults, $requirements);
 
         $routeName = 'ingalabs_image_image';

--- a/tests/Tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/Tests/DependencyInjection/ConfigurationTest.php
@@ -36,6 +36,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'prefix' => '/assets/images',
                 'driver' => 'gd',
                 'mock_image' => '%kernel.debug%',
+                'file_levels' => '2:8',
             ]
         );
     }
@@ -52,6 +53,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'prefix' => '/assets/images',
                 'driver' => 'gd',
                 'mock_image' => '%kernel.debug%',
+                'file_levels' => '2:8',
             ]
         );
     }
@@ -63,6 +65,56 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 ['doctrine_driver' => 'foo_bar'],
             ],
             'doctrine_driver'
+        );
+    }
+
+    public function testInvalidFileLevels()
+    {
+        $this->assertPartialConfigurationIsInvalid(
+            [
+                ['file_levels' => '2:e:3'],
+            ],
+            'file_levels'
+        );
+        $this->assertPartialConfigurationIsInvalid(
+            [
+                ['file_levels' => ''],
+            ],
+            'file_levels'
+        );
+        $this->assertPartialConfigurationIsInvalid(
+            [
+                ['file_levels' => '::'],
+            ],
+            'file_levels'
+        );
+        $this->assertPartialConfigurationIsInvalid(
+            [
+                ['file_levels' => '1:33'],
+            ],
+            'file_levels'
+        );
+        $this->assertPartialConfigurationIsInvalid(
+            [
+                ['file_levels' => '1:-3'],
+            ],
+            'file_levels'
+        );
+    }
+
+    public function testValidFileLevels()
+    {
+        $this->assertConfigurationIsValid(
+            [
+                ['file_levels' => '2:2:3'],
+            ],
+            'file_levels'
+        );
+        $this->assertConfigurationIsValid(
+            [
+                ['file_levels' => '2'],
+            ],
+            'file_levels'
         );
     }
 }

--- a/tests/Tests/DependencyInjection/IngaLabsImageExtensionTest.php
+++ b/tests/Tests/DependencyInjection/IngaLabsImageExtensionTest.php
@@ -36,6 +36,7 @@ class IngaLabsImageExtensionTest extends AbstractExtensionTestCase
             'prefix' => '/assets/images',
             'driver' => 'gd',
             'mock_image' => '%kernel.debug%',
+            'file_levels' => '2:8',
         ];
         $this->assertContainerBuilderHasParameter('ingalabs_image.config', $defaultConfig);
     }

--- a/tests/Tests/ImageManagerTest.php
+++ b/tests/Tests/ImageManagerTest.php
@@ -78,6 +78,28 @@ class ImageManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($dn['name'], '01234567890123456789012345678901_sm_1x1.jpg');
     }
 
+    public function testGetDirectoryAndNameForFileLevels()
+    {
+        $image = new Image();
+        $image
+            ->setHash('01234567890123456789012345678901')
+            ->setType('jpg');
+
+        $managerRegistry = $this->getManagerRegistryMock();
+        $imageManager = new ImageManager($managerRegistry, ['prefix' => '/images', 'file_levels' => '4:6:8']);
+
+        $reflector = new \ReflectionClass(ImageManager::class);
+        $method = $reflector->getMethod('getDirectoryAndNameFor');
+        $method->setAccessible(true);
+
+        $dn = $method->invokeArgs($imageManager, [$image]);
+        $this->assertSame($dn['directory'], '/images/0123/012345/01234567');
+        $this->assertSame($dn['name'], '01234567890123456789012345678901_or_or.jpg');
+
+        $dn = $method->invokeArgs($imageManager, [$image, 'sm', '1x1']);
+        $this->assertSame($dn['name'], '01234567890123456789012345678901_sm_1x1.jpg');
+    }
+
     public function testGetUrlFor()
     {
         $date = new \DateTime('1986-07-23 23:40:40', new \DateTimeZone('Europe/Budapest'));

--- a/tests/Tests/Routing/Loader/ImageLoaderTest.php
+++ b/tests/Tests/Routing/Loader/ImageLoaderTest.php
@@ -50,11 +50,37 @@ class ImageLoaderTest extends \PHPUnit_Framework_TestCase
         $route = $routeCollection->get('ingalabs_image_image');
         $this->assertSame(1, $routeCollection->count());
         $this->assertInstanceOf('Symfony\Component\Routing\Route', $route);
-        $this->assertSame($prefix.'/{hash2}/{hash8}/{hash}_{size}_{aspect}.{type}', $route->getPath());
+        $this->assertSame($prefix.'/{hash0}/{hash1}/{hash}_{size}_{aspect}.{type}', $route->getPath());
         $this->assertSame('ingalabs_image.image_controller:showAction', $route->getDefault('_controller'));
         $reqirements = [
-            'hash2' => '[a-zA-Z0-9]{2}',
-            'hash8' => '[a-zA-Z0-9]{8}',
+            'hash0' => '[a-zA-Z0-9]{2}',
+            'hash1' => '[a-zA-Z0-9]{8}',
+            'hash' => '[a-zA-Z0-9]{32}',
+            'size' => '[a-zA-Z0-9]+',
+            'aspect' => '[a-zA-Z0-9]+',
+            'type' => '[a-zA-Z0-9]+',
+        ];
+        foreach ($reqirements as $param => $requirement) {
+            $this->assertSame($requirement, $route->getRequirement($param));
+        }
+    }
+
+    public function testLoadFileLevels()
+    {
+        $prefix = '/foo/bar';
+        $loader = new ImageLoader(['prefix' => $prefix, 'file_levels' => '4:6:8']);
+        $routeCollection = $loader->load('.', 'ingalabs_image');
+        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $routeCollection);
+
+        $route = $routeCollection->get('ingalabs_image_image');
+        $this->assertSame(1, $routeCollection->count());
+        $this->assertInstanceOf('Symfony\Component\Routing\Route', $route);
+        $this->assertSame($prefix.'/{hash0}/{hash1}/{hash2}/{hash}_{size}_{aspect}.{type}', $route->getPath());
+        $this->assertSame('ingalabs_image.image_controller:showAction', $route->getDefault('_controller'));
+        $reqirements = [
+            'hash0' => '[a-zA-Z0-9]{4}',
+            'hash1' => '[a-zA-Z0-9]{6}',
+            'hash2' => '[a-zA-Z0-9]{8}',
             'hash' => '[a-zA-Z0-9]{32}',
             'size' => '[a-zA-Z0-9]+',
             'aspect' => '[a-zA-Z0-9]+',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC break      | no
| Tests passed? | yes
| Fixed tickets | n/a
| License       | MIT

`file_levels` sets up a multi-level directory hierarchy. Having a large number of files in a single directory can slow down file access, so it handles multi‑level directory hierarchy.