### PR TITLE
Minor test fix

### DIFF
--- a/src/Repository/ImageRepositoryTrait.php
+++ b/src/Repository/ImageRepositoryTrait.php
@@ -9,7 +9,6 @@
 
 namespace IngaLabs\Bundle\ImageBundle\Repository;
 
-use Doctrine\Common\Persistence\ObjectRepository;
 use IngaLabs\Bundle\ImageBundle\Model\Image;
 
 /**
@@ -32,9 +31,4 @@ trait ImageRepositoryTrait
             'hash' => $hash,
         ]);
     }
-
-    /**
-     * @see ObjectRepository::findOneBy
-     */
-    abstract public function findOneBy(array $criteria, array $orderBy = null);
 }

--- a/tests/Tests/Repository/ImageRepositoryTraitTest.php
+++ b/tests/Tests/Repository/ImageRepositoryTraitTest.php
@@ -9,6 +9,7 @@
 
 namespace IngaLabs\Bundle\ImageBundle\Tests\Repository;
 
+use Doctrine\Common\Persistence\ObjectRepository;
 use IngaLabs\Bundle\ImageBundle\Repository\ImageRepositoryTrait;
 
 /**
@@ -20,7 +21,7 @@ class ImageRepositoryTraitTest extends \PHPUnit_Framework_TestCase
 {
     public function testFindOneByHashCallsTheAbstractMethod()
     {
-        $repository = $this->getMockForTrait(ImageRepositoryTrait::class);
+        $repository = $this->getMockForAbstractClass(ObjectRepositoryWithImageRepositoryTraitTestClass::class);
 
         $repository
             ->expects($this->once())
@@ -31,4 +32,9 @@ class ImageRepositoryTraitTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(['hash' => 'foo_bar'], $repository->findOneByHash('foo_bar'));
     }
+}
+
+abstract class ObjectRepositoryWithImageRepositoryTraitTestClass implements ObjectRepository
+{
+    use ImageRepositoryTrait;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC break      | no
| Tests passed? | yes
| Fixed tickets | n/a
| License       | MIT

Declaration of `findOnBy` is differs in ORM and MongoDB. It fixes it.